### PR TITLE
Añadir un fichero de ejemplo palabras.txt y modificar el Makefile para que lo lea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: all $(MAKECMDGOALS)
 
 run:
-	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py palabras.txt yes

--- a/palabras.txt
+++ b/palabras.txt
@@ -1,0 +1,7 @@
+lol
+paloma
+unir
+universidad
+integracion
+entrega
+continua


### PR DESCRIPTION
Añadir un fichero de ejemplo, palabras.txt, que incluya varias palabras, una por línea, desordenadas, y modificar el Makefile para que use el nombre del fichero como parámetro de línea de comandos.